### PR TITLE
[Draft] test: add failing test for performance issue

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -83,6 +83,7 @@ const removeMarkdown = (
       // Remove reference-style links?
       .replace(/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g, "")
       // Remove atx-style headers
+      // FIXME this can be slow
       .replace(
         /^(\n)?\s{0,}#{1,6}\s+| {0,}(\n)?\s{0,}#{0,} {0,}(\n)?\s{0,}$/gm,
         "$1$2$3"

--- a/test/removeMarkdown.test.ts
+++ b/test/removeMarkdown.test.ts
@@ -187,5 +187,19 @@ describe("Remove Markdown", () => {
 
       expect(removeMarkdown(paragraph, { listUnicodeChar: false, preserveLinks: true })).to.equal(expected);
     });
+
+    it("should handle weird string fast", () => {
+      const string =
+        "                                                                                                                                                                                         .";
+      const expected =
+        "                                                                                                                                                                                         .";
+
+      const start = performance.now();
+      const removedMarkdown = removeMarkdown(string);
+      const end = performance.now();
+      expect(end - start).to.below(1000);
+      
+      expect(removedMarkdown).to.equal(expected);
+    });
   });
 });


### PR DESCRIPTION
Hi,

I have noticed the library performs very slowly with long lines of text ending with a character. This came up with some user-generated content...

I added a test and tracked down the performance issue to the 'atx-style header' regex. The test is only here for reproduction purposes.

Cheers!